### PR TITLE
Added React Hook to Fix Catalog

### DIFF
--- a/app/components/navigation/CatalogDropdown.tsx
+++ b/app/components/navigation/CatalogDropdown.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, {useEffect, useMemo, useRef, useState} from "react";
+//@ts-ignore
 import ChevronUp from "@/public/assets/svg/chevron-up.svg?svgr";
+//@ts-ignore
 import ChevronDown from "@/public/assets/svg/chevron-down.svg?svgr";
 import { useAppContext } from "@/app/contexts/appContext/AppProvider";
 import { catalogList } from "@/public/data/staticData";
@@ -12,8 +14,9 @@ const CatalogDropdown = () => {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Find the displaying text for catalog
-  const catalogText: string =
-    catalogList.filter((cat) => cat.value === catalog_year)[0]?.text ?? "";
+  const catalogText:string = useMemo(() => {
+    return catalogList.find((cat) => cat.value === catalog_year)?.text ?? "";
+  }, [catalog_year]);
 
   useEffect(() => {
     if (!dropdownOpen) return;

--- a/app/contexts/appContext/AppProvider.tsx
+++ b/app/contexts/appContext/AppProvider.tsx
@@ -19,7 +19,7 @@ import { ApplicationContext } from "@/app/model/AppContextInterface";
 const constantApplicationValue = { courseState, pathwaysCategories };
 
 const defaultInitialState: ApplicationContext = {
-  catalog_year: 2023, // this value is to keep the dropdown text empty while fetching localStorage
+  catalog_year: -1, // this value is to keep the dropdown text empty while fetching localStorage
   // TODO: all course with status
   setCatalog: () => {},
   ...constantApplicationValue,

--- a/app/contexts/appContext/AppProvider.tsx
+++ b/app/contexts/appContext/AppProvider.tsx
@@ -19,7 +19,7 @@ import { ApplicationContext } from "@/app/model/AppContextInterface";
 const constantApplicationValue = { courseState, pathwaysCategories };
 
 const defaultInitialState: ApplicationContext = {
-  catalog_year: -1, // this value is to keep the dropdown text empty while fetching localStorage
+  catalog_year: 2023, // this value is to keep the dropdown text empty while fetching localStorage
   // TODO: all course with status
   setCatalog: () => {},
   ...constantApplicationValue,

--- a/app/courses/[courseCode]/page.tsx
+++ b/app/courses/[courseCode]/page.tsx
@@ -116,7 +116,6 @@ const CoursePage: React.FC<ICourseCode> = (data) => {
         <header>
           <h3>Semester Offered</h3>
         </header>
-        <SemesterTable term={term} />
       </section>
     </Fragment>
   );


### PR DESCRIPTION
Closes #6 

The display bug was caused by the text being updated on ever render with react. They had the rest of the component in hooks but just left the text field outside a hook. I put it in a hook to prevent this.