### PR TITLE
Implement My Course Page, Add filtering by status, use CourseProp interface for updating status

### DIFF
--- a/app/api/pathway/search/route.ts
+++ b/app/api/pathway/search/route.ts
@@ -65,7 +65,7 @@ export async function GET(request: NextRequest) {
     const data = v[1];
     return {
       title: data.name,
-      courses: data.courses,
+      coursesIn: data.courses,
       department: data.department,
     };
   });

--- a/app/components/course/CourseCard.tsx
+++ b/app/components/course/CourseCard.tsx
@@ -16,7 +16,6 @@ const CourseCard = ({
   const [state, setState] = useState(status);
   const {courses, updateCourseState} = useAppContext();
   status = courses.find(course => course.name === title)?.status || "No Selection";
-  console.log(title + " " + status);
   const offeredSemesters = [];
   if (offered.fall) offeredSemesters.push("Fall");
   if (offered.spring) offeredSemesters.push("Spring");

--- a/app/components/course/CourseCard.tsx
+++ b/app/components/course/CourseCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { CourseCardProps } from "@/app/model/CourseInterface";
+import { useAppContext } from "../../contexts/appContext/AppProvider";
 import Link from "next/link";
 import CourseCardDropDown from "./CourseDropDownButton";
 
@@ -13,7 +14,9 @@ const CourseCard = ({
   status = "No Selection"
 }: CourseCardProps) => {
   const [state, setState] = useState(status);
-
+  const {courses, updateCourseState} = useAppContext();
+  status = courses.find(course => course.name === title)?.status || "No Selection";
+  console.log(title + " " + status);
   const offeredSemesters = [];
   if (offered.fall) offeredSemesters.push("Fall");
   if (offered.spring) offeredSemesters.push("Spring");
@@ -69,7 +72,7 @@ const CourseCard = ({
             </div>
           )}
         </div>
-        <CourseCardDropDown title={title} courseCode={courseCode} tag={tag} status={state} />
+        <CourseCardDropDown title={title} courseCode={courseCode} tag={tag} status={status} />
       </div>
     </section>
   );

--- a/app/components/course/CourseDropDownButton.tsx
+++ b/app/components/course/CourseDropDownButton.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { CourseCardProps } from "@/app/model/CourseInterface";
 import { useAppContext } from "../../contexts/appContext/AppProvider";
-import { SingleCourse } from "@/app/model/CourseInterface";
 import { clsx } from 'clsx';
 
 const colorMap = {
@@ -17,15 +16,14 @@ const CourseCardDropDown = ({
   status = "No Selection"
 }: CourseCardProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { coursesSelected, updateCourseInContext } = useAppContext(); // TODO: Change to use ICourseProp
-  status = coursesSelected.find(course => course.courseID === courseCode)?.status || "No Selection";
+  const {courses, updateCourseState} = useAppContext();
+  status = courses.find(course => course.name === title)?.status || "No Selection";
   const [dropDownText, setDropDownText] = useState<string>(status);
   const chipStyle = clsx("text-sm font-semibold px-2 py-2.5 border border-solid border-gray-300 rounded-lg cursor-pointer text-center", colorMap[dropDownText]);
   
   const handleOption = (newStatus: string) => {
     setDropDownText(newStatus);
-    let toAdd : SingleCourse = { courseID: courseCode, title: title, status: newStatus };
-    updateCourseInContext(toAdd);
+    updateCourseState(title, newStatus);
     setIsOpen(false);
   };
   /*

--- a/app/components/course/CourseDropDownButton.tsx
+++ b/app/components/course/CourseDropDownButton.tsx
@@ -17,13 +17,16 @@ const CourseCardDropDown = ({
 }: CourseCardProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const {courses, updateCourseState} = useAppContext();
-  status = courses.find(course => course.name === title)?.status || "No Selection";
+  //status = courses.find(course => course.name === title)?.status || "No Selection";
   const [dropDownText, setDropDownText] = useState<string>(status);
   const chipStyle = clsx("text-sm font-semibold px-2 py-2.5 border border-solid border-gray-300 rounded-lg cursor-pointer text-center", colorMap[dropDownText]);
-  
+  useEffect(() => {
+    setDropDownText(status);
+  }, [status]);
+
   const handleOption = (newStatus: string) => {
-    setDropDownText(newStatus);
     updateCourseState(title, newStatus);
+    setDropDownText(newStatus);
     setIsOpen(false);
   };
   /*

--- a/app/components/course/SearchComponent.tsx
+++ b/app/components/course/SearchComponent.tsx
@@ -26,6 +26,7 @@ import { ICourseSchema } from "@/public/data/dataInterface";
 import { flattenFilterParams } from "../utils/url";
 import dynamic from "next/dynamic";
 import { useAppContext, fetchCourses } from '@/app/contexts/appContext/AppProvider';
+import { filter } from "lodash";
 
 const Spinner = dynamic(() => import("@/app/components/utils/Spinner"));
 
@@ -348,15 +349,12 @@ const CourseList = ({
         });
       }
 
-      //console.log(filtered);
-
       if (deferredFilterState.status.length) {
         filtered = filtered.filter(course =>
-          deferredFilterState.status[0] == course.status
+          deferredFilterState.status.includes(course.status)
         );
         
       }
-      console.log(filtered);
 
       // CI and HI Filtering
       if (deferredFilterState.filter.length && tags_short_to_long) {
@@ -394,7 +392,7 @@ const CourseList = ({
   return (
     <section className="grid grid-cols-3 gap-4">
       {isLoading ? <Spinner /> : filteredCourses.map((course, i) => (
-        
+        console.log(course.status),
         <CourseCard 
           title={course.name}
           courseCode={course.subj + '-' + course.ID}

--- a/app/components/course/SearchComponent.tsx
+++ b/app/components/course/SearchComponent.tsx
@@ -391,11 +391,10 @@ const CourseList = ({
 
     applyFilters();
   }, [deferredSearchString, deferredFilterState, courses]);
-
+  // TODO: Make it so that this css can be changed depending on where the course list is being used (clsx)
   return (
-    <section className="grid grid-cols-3 gap-4">
+    <section className="grid grid-cols-4 gap-4">
       {isLoading ? <Spinner /> : filteredCourses.map((course, i) => (
-        console.log(course.status),
         <CourseCard 
           title={course.name}
           courseCode={course.subj + '-' + course.ID}

--- a/app/components/course/SearchComponent.tsx
+++ b/app/components/course/SearchComponent.tsx
@@ -83,6 +83,36 @@ export const FilterSection = ({
   );
 };
 
+export const MyCourseDesktopFilterSection = ({
+  filterState,
+  filterDispatch,
+  searchString,
+  setSearchString,
+}: FilterSectionProps) => {
+  return (
+    <>
+      <div className="filters flex justify-start items-start gap-8 mb-4 md:mb-8">
+        <div className="grow flex flex-col gap-4">
+          <CourseList searchString={searchString} filterState={filterState} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export const MyCourseFilterSection = ({
+  filterState,
+  filterDispatch,
+  setSearchString,
+  searchString,
+}: FilterSectionProps) => {
+  return (
+    <>
+      <CourseList searchString={searchString} filterState={filterState} />
+    </>
+  );
+}
+
 const SearchInput = ({ searchString, setSearchString }: SearchInputProps) => {
   return (
     <label htmlFor="course-input" className="basis-0 grow">
@@ -211,7 +241,7 @@ const CourseList = ({
   const deferredFilterState = useDeferredValue(filterState);
   const { catalog_year, courses, fetchCourses} = useAppContext();
 
-
+  
   useEffect(() => {
     const fetchData = async () => {
       setIsLoading(true);
@@ -220,6 +250,8 @@ const CourseList = ({
     };
     fetchData();
   }, [catalog_year]);
+
+  
 
   useEffect(() => {
     const tags_short_to_long = courseFilters.reduce((acc, section) => {
@@ -261,6 +293,16 @@ const CourseList = ({
           return deferredFilterState.semester.some(sem => offeredSemesters.includes(sem));
         });
       }
+
+      console.log(filtered);
+
+      if (deferredFilterState.status.length) {
+        filtered = filtered.filter(course =>
+          deferredFilterState.status[0] == course.status
+        );
+        
+      }
+      console.log(filtered);
 
       // CI and HI Filtering
       if (deferredFilterState.filter.length && tags_short_to_long) {

--- a/app/components/course/SearchComponent.tsx
+++ b/app/components/course/SearchComponent.tsx
@@ -18,6 +18,7 @@ import CourseCard from "./CourseCard";
 import {
   FilterProps,
   FilterSectionProps,
+  IFilterDispatch,
   IFilterState,
   SearchInputProps,
 } from "@/app/model/CourseInterface";
@@ -28,10 +29,63 @@ import { useAppContext, fetchCourses } from '@/app/contexts/appContext/AppProvid
 
 const Spinner = dynamic(() => import("@/app/components/utils/Spinner"));
 
+// Actions for Filter Reducer
+
 export const FilterAction = {
   ADD: "add",
   REM: "remove",
+  RESET: "reset",
+  SET: "set",
 };
+
+// Default Filter Values
+
+export const filterInitializers = {
+  filter: [],
+  level: [],
+  prefix: [],
+  semester: [],
+  prereq: [],
+  status: [],
+};
+
+// Reduces "IFilterState" to a new state based on the action dispatched
+
+export const filterReducer = (state: IFilterState, action: IFilterDispatch) => {
+  switch (action.type) {
+    case FilterAction.ADD:
+      return {
+        ...state,
+        [action.payload.group]: [
+          ...state[action.payload.group],
+          action.payload.value,
+        ],
+      };
+    case FilterAction.REM:
+      return {
+        ...state,
+        [action.payload.group]: state[action.payload.group].filter(
+          (e: string) => e !== action.payload.value
+        ),
+      };
+    case FilterAction.RESET:
+      return {
+        filter: [],
+        level: [],
+        prefix: [],
+        semester: [],
+        prereq: [],
+        status: [],
+      };
+    case FilterAction.SET:
+      return {
+        ...state,
+        [action.payload.group]: action.payload.value,
+      };
+    default:
+      return state;
+  }
+}
 
 export const DesktopFilterSection = ({
   filterState,
@@ -294,7 +348,7 @@ const CourseList = ({
         });
       }
 
-      console.log(filtered);
+      //console.log(filtered);
 
       if (deferredFilterState.status.length) {
         filtered = filtered.filter(course =>

--- a/app/components/course/SearchComponent.tsx
+++ b/app/components/course/SearchComponent.tsx
@@ -138,6 +138,9 @@ export const FilterSection = ({
   );
 };
 
+// TODO: Have Website fetch courses no matter what page is used, not just the search page.
+// Generates a list of courses based on the filter state and search string (which is empty in this case)
+
 export const MyCourseDesktopFilterSection = ({
   filterState,
   filterDispatch,

--- a/app/components/pathway/PathwayCard.tsx
+++ b/app/components/pathway/PathwayCard.tsx
@@ -4,7 +4,7 @@ import { IPathwaySchema } from "@/public/data/dataInterface";
 import { useAppContext } from "@/app/contexts/appContext/AppProvider";
 import { HelpBox } from "./helpBox";
 
-const PathwayCard = ({ title, department, courses }: IPathwaySchema) => {
+const PathwayCard = ({ title, department, coursesIn }: IPathwaySchema) => {
   // TODO: use courses to determine the compatibility
   // TODO: change to bookmark state and update React Context
   // TODO: Compute tooltip
@@ -12,6 +12,7 @@ const PathwayCard = ({ title, department, courses }: IPathwaySchema) => {
   const [bookmark, setBookmark] = useState(false);
   const [isShown, setIsShown] = useState(false);
   const { coursesSelected, setCoursesSelected } = useAppContext();
+  const { courses } = useAppContext();
   const getBookmarks = () => {
     var bmks = localStorage.getItem("bookmarks")
     if (bmks == null) {
@@ -27,7 +28,7 @@ const PathwayCard = ({ title, department, courses }: IPathwaySchema) => {
     if (bookmark)
       current = current.filter(i => i.title != title);
     else if (current.find(x => x.title === title) == undefined) {
-      current.push({ title: title, department: department, courses: courses });
+      current.push({ title: title, department: department, coursesIn: coursesIn });
     }
     localStorage.setItem("bookmarks", JSON.stringify(current));
     setBookmark(!bookmark);
@@ -36,31 +37,29 @@ const PathwayCard = ({ title, department, courses }: IPathwaySchema) => {
   useEffect(() => {
     getBookmarks();
   }, [])
-  console.log(courses);
   // Statuses: Planned, In Progress, Interested, No Selection
-  console.log(coursesSelected);
-  const inPathway = coursesSelected.filter((course) => courses.includes(course.courseID));
+  const inPathway = courses.filter((course) => coursesIn.includes(course.name));
   const completed = inPathway.filter((course) => course.status === "Completed");
   const completedItems = completed.map((course) => (
-    <div key={course.courseID} className="flex gap-2 items-center">
+    <div key={course.courseCode} className="flex gap-2 items-center">
       <p className="text-sm text-green-500">✔</p>
-      <b className="text-sm">{course.courseID}:</b>
+      <b className="text-sm">{course.courseCode}:</b>
       <p className="text-sm">{course.title}</p>
     </div>
   ));
   const inProgress = inPathway.filter((course) => course.status === "In Progress");
   const inProgressItems = inProgress.map((course) => (
-    <div key={course.courseID} className="flex gap-2 items-center">
+    <div key={course.courseCode} className="flex gap-2 items-center">
       <p className="text-sm text-yellow-500">⏺</p>
-      <b className="text-sm">{course.courseID}:</b>
+      <b className="text-sm">{course.courseCode}:</b>
       <p className="text-sm">{course.title}</p>
     </div>
   ));
   const planned = inPathway.filter((course) => course.status === "Planned");
   const plannedItems = planned.map((course) => (
-    <div key={course.courseID} className="flex gap-2 items-center">
+    <div key={course.courseCode} className="flex gap-2 items-center">
       <p className="text-sm text-gray-500">⏺</p>
-      <b className="text-sm">{course.courseID}:</b>
+      <b className="text-sm">{course.courseCode}:</b>
       <p className="text-sm">{course.title}</p>
     </div>
   ));

--- a/app/components/pathway/PathwayCard.tsx
+++ b/app/components/pathway/PathwayCard.tsx
@@ -3,6 +3,7 @@ import { Bookmark, BookmarkChecked, HelpIcon } from "../utils/Icon";
 import { IPathwaySchema } from "@/public/data/dataInterface";
 import { useAppContext } from "@/app/contexts/appContext/AppProvider";
 import { HelpBox } from "./helpBox";
+import { courseState } from "@/public/data/staticData";
 
 const PathwayCard = ({ title, department, coursesIn }: IPathwaySchema) => {
   // TODO: use courses to determine the compatibility
@@ -11,7 +12,6 @@ const PathwayCard = ({ title, department, coursesIn }: IPathwaySchema) => {
   
   const [bookmark, setBookmark] = useState(false);
   const [isShown, setIsShown] = useState(false);
-  const { coursesSelected, setCoursesSelected } = useAppContext();
   const { courses } = useAppContext();
   const getBookmarks = () => {
     var bmks = localStorage.getItem("bookmarks")
@@ -23,6 +23,7 @@ const PathwayCard = ({ title, department, coursesIn }: IPathwaySchema) => {
     }
   }
 
+  
   const toggleBookmark = () => {
     let current: IPathwaySchema[] = JSON.parse(localStorage.getItem("bookmarks"));
     if (bookmark)
@@ -33,36 +34,60 @@ const PathwayCard = ({ title, department, coursesIn }: IPathwaySchema) => {
     localStorage.setItem("bookmarks", JSON.stringify(current));
     setBookmark(!bookmark);
   }
+  
 
   useEffect(() => {
     getBookmarks();
   }, [])
-  // Statuses: Planned, In Progress, Interested, No Selection
-  const inPathway = courses.filter((course) => coursesIn.includes(course.name));
+  // Statuses: Completed, In Progress, Planned, No Selection
+  console.log(title);
+  //console.log(coursesIn);
+  
+  console.log(courses);
+  const inPathway = courses.filter((course) => coursesIn.includes(course.subj + "-" + course.ID));
+  console.log(inPathway);
+  /*
+  let items = [];
+  const statuses = courseState.map((state) => state.display);
+  for (let status of statuses) {
+    const statusCourses = inPathway.filter((course) => course.status === status);
+    const statusItems = statusCourses.map((course) => (
+      <div key={course.courseCode} className="flex gap-2 items-center">
+        <p className="text-sm text-green-500">✔</p>
+        <b className="text-sm">{course.courseCode}:</b>
+        <p className="text-sm">{course.title}</p>
+      </div>
+    ));
+    items.push(statusItems);
+    console.log(courses);
+  }
+  */
+  
   const completed = inPathway.filter((course) => course.status === "Completed");
   const completedItems = completed.map((course) => (
-    <div key={course.courseCode} className="flex gap-2 items-center">
+    <div key={course.subj + "-" + course.ID} className="flex gap-2 items-center">
       <p className="text-sm text-green-500">✔</p>
-      <b className="text-sm">{course.courseCode}:</b>
-      <p className="text-sm">{course.title}</p>
+      <b className="text-sm">{course.subj + "-" + course.ID}:</b>
+      <p className="text-sm">{course.name}</p>
     </div>
   ));
   const inProgress = inPathway.filter((course) => course.status === "In Progress");
   const inProgressItems = inProgress.map((course) => (
-    <div key={course.courseCode} className="flex gap-2 items-center">
+    <div key={course.subj + "-" + course.ID} className="flex gap-2 items-center">
       <p className="text-sm text-yellow-500">⏺</p>
-      <b className="text-sm">{course.courseCode}:</b>
-      <p className="text-sm">{course.title}</p>
+      <b className="text-sm">{course.subj + "-" + course.ID}:</b>
+      <p className="text-sm">{course.name}</p>
     </div>
   ));
   const planned = inPathway.filter((course) => course.status === "Planned");
   const plannedItems = planned.map((course) => (
-    <div key={course.courseCode} className="flex gap-2 items-center">
+    <div key={course.subj + "-" + course.ID} className="flex gap-2 items-center">
       <p className="text-sm text-gray-500">⏺</p>
-      <b className="text-sm">{course.courseCode}:</b>
-      <p className="text-sm">{course.title}</p>
+      <b className="text-sm">{course.subj + "-" + course.ID}:</b>
+      <p className="text-sm">{course.name}</p>
     </div>
   ));
+  
   return (
     <section className="pathway-card">
       <header className="flex justify-between w-full items-start">

--- a/app/components/pathway/PathwayCard.tsx
+++ b/app/components/pathway/PathwayCard.tsx
@@ -39,13 +39,11 @@ const PathwayCard = ({ title, department, coursesIn }: IPathwaySchema) => {
   useEffect(() => {
     getBookmarks();
   }, [])
-  // Statuses: Completed, In Progress, Planned, No Selection
-  console.log(title);
-  //console.log(coursesIn);
+  // Statuses: Completed, In Progress, Planned, Interested, No Selection
   
-  console.log(courses);
   const inPathway = courses.filter((course) => coursesIn.includes(course.subj + "-" + course.ID));
-  console.log(inPathway);
+
+  // TODO: map status to display so that we don't need different variables for each status
   /*
   let items = [];
   const statuses = courseState.map((state) => state.display);

--- a/app/contexts/appContext/AppProvider.tsx
+++ b/app/contexts/appContext/AppProvider.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/public/data/staticData";
 import { ApplicationContext } from "@/app/model/AppContextInterface";
 import { ICourseSchema } from "@/app/model/CourseInterface";
-import { SingleCourse } from "@/app/model/CourseInterface";
 
 const constantApplicationValue = { courseState, pathwaysCategories };
 
@@ -25,10 +24,9 @@ const defaultInitialState: ApplicationContext = {
   courses: [],
   coursesSelected: [],
   setCourses: () => {},
-  setCoursesSelected: () => {},
   setCatalog: () => {},
   fetchCourses: () => {},
-  updateCourseInContext: () => {},
+  updateCourseState: () => {},
   ...constantApplicationValue,
 };
 
@@ -62,29 +60,21 @@ const AppContextProvider = ({ children }: { children: ReactNode }) => {
     dispatch({ type: SET_CATALOG, payload: catalog_year });
   };
 
+  const updateCourseState = (name: string, status: string) => {
+    const courses = state.courses;
+    const updatedCourses = courses.map(course =>
+      course.name === name
+        ? { ...course, status: status }
+        : course);
+    setCourses(updatedCourses);
+  };
+
   const setCourses = (courses: ICourseSchema[]) => {
     console.log("SETTING COURSES");
     dispatch({ type: SET_COURSES, payload: courses });
+    localStorage.setItem("courses", JSON.stringify(courses));
+    fetchCourses();
   };
-
-  const updateCourseInContext = (toAdd: SingleCourse) => {
-    const newState = toAdd.status;
-    const coursesSelected = state.coursesSelected;
-    const updatedCourses = coursesSelected.map(course =>
-      course.courseID === toAdd.courseID
-        ? { ...course, status: newState }
-        : course);
-    let selectedIDS = updatedCourses.map(course => course.courseID);
-
-    if (!selectedIDS.includes(toAdd.courseID)) {
-      updatedCourses.push(toAdd);
-    }
-    setCoursesSelected(updatedCourses);
-  };
-
-  const setCoursesSelected = (courses: SingleCourse[]) => {
-    dispatch({ type: SET_COURSES_SELECTED, payload: courses });
-  }
 
   const fetchCourses = async () => {
     const localStorageCourses = localStorage.getItem("courses");
@@ -126,7 +116,7 @@ const AppContextProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <AppContext.Provider value={{ ...state, setCatalog, setCourses, setCoursesSelected, updateCourseInContext, fetchCourses }}>
+    <AppContext.Provider value={{ ...state, setCatalog, setCourses, updateCourseState, fetchCourses }}>
       {children}
     </AppContext.Provider>
   );

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -9,14 +9,9 @@ import ChevronRight from "@/public/assets/svg/chevron-right.svg?svgr";
 import { useAppContext } from "../contexts/appContext/AppProvider";
 import { ICourseSchema } from "../../public/data/dataInterface";
 import { CourseCardProps } from "@/app/model/CourseInterface";
-import { MyCourseFilterSection, MyCourseDesktopFilterSection } from "@/app/components/course/SearchComponent";
+import { MyCourseFilterSection, MyCourseDesktopFilterSection, FilterAction, filterReducer, filterInitializers } from "@/app/components/course/SearchComponent";
 import { IFilterDispatch, IFilterState } from "@/app/model/CourseInterface";
 import { filter } from "lodash";
-
-export const FilterAction = {
-  ADD: "add",
-  REM: "remove",
-};
 
 const MyCourses = () => {
   const [courseFilter, setCourseFilter] = useState(0);
@@ -24,37 +19,7 @@ const MyCourses = () => {
   const { courses, fetchCourses, courseState } = useAppContext();
   const [filteredCourses, setFilteredCourses] = useState();
 
-  const [filterState, filterDispatch] = useReducer(
-    (state: IFilterState, action: IFilterDispatch) => {
-      switch (action.type) {
-        case FilterAction.ADD:
-          return {
-            ...state,
-            [action.payload.group]: [
-              ...state[action.payload.group],
-              action.payload.value,
-            ],
-          };
-        case FilterAction.REM:
-          return {
-            ...state,
-            [action.payload.group]: state[action.payload.group].filter(
-              (e: string) => e !== action.payload.value
-            ),
-          };
-        default:
-          return state;
-      }
-    },
-    {
-      filter: [],
-      level: [],
-      prefix: [],
-      semester: [],
-      prereq: [],
-      status: [],
-    }
-  );
+  const [filterState, filterDispatch] = useReducer(filterReducer, filterInitializers);
 
   const [searchString, setSearchString] = useState<string>("");
 
@@ -86,8 +51,8 @@ const MyCourses = () => {
               clickCallback={() => {
                 if (filterState.status.length === 0) return;
                 let clickPayload = {
-                  type: FilterAction.REM,
-                  payload: { group: "status", value: filterState.status[0]},
+                  type: FilterAction.SET,
+                  payload: { group: "status", value: [] },
                 }
                 filterDispatch(clickPayload);
               }}
@@ -100,13 +65,8 @@ const MyCourses = () => {
                   tag={0}
                   key={state.display}
                   clickCallback={() => {
-                    let remPayload = {
-                      type: FilterAction.REM,
-                      payload: { group: "status", value: filterState.status[0] },
-                    }
-                    filterDispatch(remPayload);
                     let clickPayload = {
-                      type: FilterAction.ADD,
+                      type: FilterAction.SET,
                       payload: { group: "status", value: [state.display] },
                     }
                     filterDispatch(clickPayload);

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -26,10 +26,6 @@ const MyCourses = () => {
 
   const [searchString, setSearchString] = useState<string>("");
   let statuses = courseState.map((state) => state.display);
-  useEffect(() => {
-    
-    console.log(courses);
-  }, []);
   
 
   return (

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -18,17 +18,19 @@ const MyCourses = () => {
   const [isLoading, setIsLoading] = useState(true);
   const { courses, fetchCourses, courseState } = useAppContext();
   const [filteredCourses, setFilteredCourses] = useState();
-
-  const [filterState, filterDispatch] = useReducer(filterReducer, filterInitializers);
+  const allInitializer = {
+    ...filterInitializers,
+    status: courseState.map((state) => state.display),
+  }
+  const [filterState, filterDispatch] = useReducer(filterReducer, allInitializer);
 
   const [searchString, setSearchString] = useState<string>("");
-
+  let statuses = courseState.map((state) => state.display);
   useEffect(() => {
     
     console.log(courses);
-
   }, []);
-  let statuses = courseState.map((state) => state.display);
+  
 
   return (
     <>
@@ -48,7 +50,7 @@ const MyCourses = () => {
               label={"All"}
               tag={0}
               clickCallback={() => {
-                if (filterState.status.length === 0) return;
+                if (filterState.status.length === 3) return;
                 let clickPayload = {
                   type: FilterAction.SET,
                   payload: { group: "status", value: statuses },

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -48,7 +48,7 @@ const MyCourses = () => {
             <ModeRadioButton
               checked={filterState.status.length === statuses.length} 
               label={"All"}
-              tag={0}
+              tag={courses.filter((course) => course.status !== "No Selection").length}
               clickCallback={() => {
                 if (filterState.status.length === 3) return;
                 let clickPayload = {
@@ -63,7 +63,7 @@ const MyCourses = () => {
                 <ModeRadioButton
                   checked={state.display === filterState.status.join("")}
                   label={state.display}
-                  tag={0}
+                  tag={courses.filter((course) => course.status === state.display).length}
                   key={state.display}
                   clickCallback={() => {
                     let clickPayload = {

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -28,8 +28,7 @@ const MyCourses = () => {
     console.log(courses);
 
   }, []);
-  console.log(courses);
-  console.log(filterState)
+  let statuses = courseState.map((state) => state.display);
 
   return (
     <>
@@ -45,14 +44,14 @@ const MyCourses = () => {
         <section>
           <div className="course-button-group sm:flex flex-wrap gap-x-2 hidden">
             <ModeRadioButton
-              checked={filterState.status.length === 0}
+              checked={filterState.status.length === statuses.length} 
               label={"All"}
               tag={0}
               clickCallback={() => {
                 if (filterState.status.length === 0) return;
                 let clickPayload = {
                   type: FilterAction.SET,
-                  payload: { group: "status", value: [] },
+                  payload: { group: "status", value: statuses },
                 }
                 filterDispatch(clickPayload);
               }}

--- a/app/courses/search/page.tsx
+++ b/app/courses/search/page.tsx
@@ -5,43 +5,15 @@ import {
   FilterSection,
   DesktopFilterSection,
   FilterAction,
+  filterReducer, 
+  filterInitializers,
 } from "@/app/components/course/SearchComponent";
 import Link from "next/link";
 import ChevronRight from "@/public/assets/svg/chevron-right.svg?svgr";
 import { IFilterDispatch, IFilterState } from "@/app/model/CourseInterface";
 
 const SearchCourse = () => {
-  const [filterState, filterDispatch] = useReducer(
-    (state: IFilterState, action: IFilterDispatch) => {
-      switch (action.type) {
-        case FilterAction.ADD:
-          return {
-            ...state,
-            [action.payload.group]: [
-              ...state[action.payload.group],
-              action.payload.value,
-            ],
-          };
-        case FilterAction.REM:
-          return {
-            ...state,
-            [action.payload.group]: state[action.payload.group].filter(
-              (e: string) => e !== action.payload.value
-            ),
-          };
-        default:
-          return state;
-      }
-    },
-    {
-      filter: [],
-      level: [],
-      prefix: [],
-      semester: [],
-      prereq: [],
-      status: [],
-    }
-  );
+  const [filterState, filterDispatch] = useReducer(filterReducer, filterInitializers);
 
   const [searchString, setSearchString] = useState<string>("");
 

--- a/app/courses/search/page.tsx
+++ b/app/courses/search/page.tsx
@@ -39,6 +39,7 @@ const SearchCourse = () => {
       prefix: [],
       semester: [],
       prereq: [],
+      status: [],
     }
   );
 

--- a/app/model/AppContextInterface.ts
+++ b/app/model/AppContextInterface.ts
@@ -1,6 +1,6 @@
 import { IcourseStatus, IpathwayData } from "@/public/data/staticInterface";
 
-import { CourseCardProps, SingleCourse } from "@/app/model/CourseInterface";
+import { CourseCardProps } from "@/app/model/CourseInterface";
 import { fetchCourses } from '@/app/contexts/appContext/AppProvider';
 
 export interface ApplicationContext {
@@ -9,9 +9,7 @@ export interface ApplicationContext {
   pathwaysCategories: any; 
   courses: CourseCardProps[];
   setCourses: (courses: CourseCardProps[]) => void;
-  coursesSelected: SingleCourse[]; 
-  updateCourseInContext: (course: SingleCourse) => void;
-  setCoursesSelected: (courses: SingleCourse[]) => void; 
+  updateCourseState: (name: string, status: string) => void;
   setCatalog: (catalog_year: string) => void;
   fetchCourses: () => JSON;
 }

--- a/app/model/CourseInterface.ts
+++ b/app/model/CourseInterface.ts
@@ -47,7 +47,7 @@ export interface IFilterState {
   status?: string;         
 }
 
-export type filterType = "filter" | "level" | "prefix" | "semester" | "prereq";
+export type filterType = "filter" | "level" | "prefix" | "semester" | "prereq" | "status";
 
 export interface IFilterDispatch {
   type: string;

--- a/app/model/CourseInterface.ts
+++ b/app/model/CourseInterface.ts
@@ -22,12 +22,6 @@ sections: {1: Object}
 subj: "ARTS"
 */
 
-export interface SingleCourse {
-  courseID: string;
-  title: string;
-  status: string;
-}
-
 export interface CourseCardProps {
   ID: string;                   // Course ID
   crosslisted: Array<string>;   // List of cross-listed courses

--- a/app/pathways/page.tsx
+++ b/app/pathways/page.tsx
@@ -16,7 +16,7 @@ const pathwayList = [
   {
     name: "Graphic and Interactive Media Design",
     category: "Communication & Media",
-    courses: [
+    coursesIn: [
       {
         title: "abc",
         courseCode: "ARTS-1050",
@@ -37,7 +37,7 @@ const pathwayList = [
   {
     name: "Information Technology and Web Science",
     category: "Inter",
-    courses: [
+    coursesIn: [
       {
         title: "abc",
         courseCode: "ARTS-1050",

--- a/app/pathways/page.tsx
+++ b/app/pathways/page.tsx
@@ -63,7 +63,7 @@ const MyPathways = () => {
   const { pathwaysCategories } = useAppContext();
   // Determine the mode of pathway card
   const [bookmarkedState, setbookmarkedState] = useState(true);
-  const [marked, setMarked] = useState([]);
+  const [marked, setMarked] = useState<IPathwaySchema[]>([]);
 
   const MAX_FILTER = (1 << pathwaysCategories.length) - 1;
   // Determine the filter

--- a/app/pathways/search/page.tsx
+++ b/app/pathways/search/page.tsx
@@ -130,7 +130,8 @@ const SearchCourse = () => {
                 label="All"
                 checked={filterState === MAX_FILTER}
               />
-              {pathwaysCategories.map((pathway, i) => (
+              {
+              pathwaysCategories.map((pathway, i) => (
                 <FilterCheckBox
                   checked={activeFilter(filterState, i)}
                   key={pathway.value}

--- a/app/pathways/search/page.tsx
+++ b/app/pathways/search/page.tsx
@@ -85,7 +85,6 @@ const SearchCourse = () => {
       .then((data) => data.json())
       .then((data) => {
         setResultPathways(data);
-        console.log("Fetched data:", data);
       })
       .catch((err) => {
         if (err.name === "AbortError") return;
@@ -99,7 +98,6 @@ const SearchCourse = () => {
   }, [deferFilterState, deferSearchString, catalog_year]);
 
   useEffect(() => {
-    console.log("Updated resultPathways:", resultPathways);
   }, [resultPathways]);
 
   return (

--- a/public/data/dataInterface.ts
+++ b/public/data/dataInterface.ts
@@ -20,7 +20,7 @@ export interface ICourseSchema {
 
 export interface IPathwaySchema {
   title: string;
-  courses: string[];
+  coursesIn: string[];
   department: string;
 }
 

--- a/public/data/staticData.ts
+++ b/public/data/staticData.ts
@@ -20,8 +20,6 @@ export const courseState: Array<IcourseStatus> = [
   { display: "Completed", value: 1 },
   { display: "In Progress", value: 2 },
   { display: "Planned", value: 3 },
-  { display: "Interested", value: 4 },
-  { display: "Not Selected", value: 5 },
 ];
 
 
@@ -141,6 +139,28 @@ export const courseFilters: Array<IcourseFilter> = [
       {
         displayName: "Summer",
         value: "U",
+      },
+    ],
+  },
+  {
+    displayName: "Status",
+    apiName: "status",
+    options: [
+      {
+        displayName: "Completed",
+        value: "Completed",
+      },
+      {
+        displayName: "In Progress",
+        value: "In Progress",
+      },
+      {
+        displayName: "Planned",
+        value: "Planned",
+      },
+      {
+        displayName: "No Selection",
+        value: "No Selection",
       },
     ],
   },


### PR DESCRIPTION
Does what it says in the title. Additionally, implements counts for states on the my courses page, reorganizes the tabs on the my courses page, and stores course statuses in local storage for fetching.

![image](https://github.com/user-attachments/assets/979806be-569a-4e81-98b8-87b615e3a6a4)

![image](https://github.com/user-attachments/assets/a11c0e61-945b-4743-8c40-231d2eca8bbb)

![image](https://github.com/user-attachments/assets/f47deb05-6514-4977-9070-4c2ff48a09b9)
