### PR TITLE
Fix Refresh Persistence Bug

### DIFF
--- a/app/contexts/appContext/AppProvider.tsx
+++ b/app/contexts/appContext/AppProvider.tsx
@@ -1,28 +1,17 @@
 "use client";
 
-import {
-  createContext,
-  useContext,
-  useReducer,
-  useEffect,
-  ReactNode,
-} from "react";
-import { appReducer } from "./AppReducer";
-import { INITIAL_LOAD_DATA, SET_CATALOG, SET_COURSES, SET_COURSES_SELECTED } from "../actions";
-import {
-  courseState,
-  pathwaysCategories,
-  APPLICATION_STATE_KEY,
-} from "@/public/data/staticData";
-import { ApplicationContext } from "@/app/model/AppContextInterface";
-import { ICourseSchema } from "@/app/model/CourseInterface";
+import {createContext, ReactNode, useContext, useEffect, useReducer,} from "react";
+import {appReducer} from "./AppReducer";
+import {INITIAL_LOAD_DATA, SET_CATALOG, SET_COURSES} from "../actions";
+import {APPLICATION_STATE_KEY, courseState, pathwaysCategories,} from "@/public/data/staticData";
+import {ApplicationContext} from "@/app/model/AppContextInterface";
+import {ICourseSchema} from "@/app/model/CourseInterface";
 
 const constantApplicationValue = { courseState, pathwaysCategories };
 
 const defaultInitialState: ApplicationContext = {
   catalog_year: "2022-2023",
   courses: [],
-  coursesSelected: [],
   setCourses: () => {},
   setCatalog: () => {},
   fetchCourses: () => {},
@@ -37,27 +26,33 @@ const AppContextProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     const localStorageString = localStorage.getItem(APPLICATION_STATE_KEY);
-    const stateWithoutLocalStorage = {
-      ...defaultInitialState,
-      catalog_year: "2022-2023",
-    };
-
     const initialState = localStorageString
       ? JSON.parse(localStorageString)
-      : stateWithoutLocalStorage;
+      : defaultInitialState;
 
     dispatch({
       type: INITIAL_LOAD_DATA,
       payload: initialState,
     });
+
+    //Set the localStorage with the new initial state
+    localStorage.setItem(APPLICATION_STATE_KEY,JSON.stringify(initialState));
   }, []);
 
-  useEffect(() => {
-    localStorage.setItem(APPLICATION_STATE_KEY, JSON.stringify(state));
-  }, [state]);
 
   const setCatalog = (catalog_year: string) => {
     dispatch({ type: SET_CATALOG, payload: catalog_year });
+
+    //Check if local stoarage value exists and if it does update with the new catalog year
+    const storedStateString = localStorage.getItem(APPLICATION_STATE_KEY);
+    if (storedStateString) {
+      const storedState = JSON.parse(storedStateString);
+      const updatedState = {
+        ...storedState,
+        catalog_year: catalog_year
+      };
+      localStorage.setItem(APPLICATION_STATE_KEY, JSON.stringify(updatedState));
+    }
   };
 
   const updateCourseState = (name: string, status: string) => {
@@ -72,8 +67,20 @@ const AppContextProvider = ({ children }: { children: ReactNode }) => {
   const setCourses = (courses: ICourseSchema[]) => {
     console.log("SETTING COURSES");
     dispatch({ type: SET_COURSES, payload: courses });
+
+    //Get the localStorage value and if it exists update the course
+    const storedStateString = localStorage.getItem(APPLICATION_STATE_KEY);
+    if (storedStateString) {
+      const storedState = JSON.parse(storedStateString);
+      const updatedState = {
+        ...storedState,
+        courses: courses
+      };
+      localStorage.setItem(APPLICATION_STATE_KEY, JSON.stringify(updatedState));
+    }
+    //Currently have two different values in local storage being used for courses
+    //TODO Refactor to one single value for localStorage
     localStorage.setItem("courses", JSON.stringify(courses));
-    fetchCourses();
   };
 
   const fetchCourses = async () => {

--- a/app/contexts/appContext/AppReducer.tsx
+++ b/app/contexts/appContext/AppReducer.tsx
@@ -13,7 +13,11 @@ export const appReducer: (
 ) => {
   switch (action.type) {
     case INITIAL_LOAD_DATA:
-      return action.payload;
+      return {
+        ...state,
+        catalog_year: action.payload.catalog_year,
+        courses: action.payload.courses,
+      };
     case SET_CATALOG:
       return {
         ...state,
@@ -23,11 +27,6 @@ export const appReducer: (
       return {
         ...state,
         courses: action.payload,
-      };
-    case SET_COURSES_SELECTED:
-      return {
-        ...state,
-        coursesSelected: action.payload,
       };
     default:
       return state;


### PR DESCRIPTION
Closes #49 

The cause of this bug was we weren't properly updating the application state in the local Storage with the course data. And when you refresh the page the code checked only the application state key for data to persist across refreshes. What this PR does is it makes it so when you update either of the two values (catalog year or courses) in the app context it updates the application value in local storage with the necessary data. 

I also went about and removed unused code from the app provider. In particular the courses selected values in the app context was completely unused. We also were updating the state values via a useEffect hook before. I got rid of this and replaced it with logic inside of the set logics.

Some things to consider after this PR, #43 introduced a new variable in local Storage "courses". This value is now redundant with this fix to the application state key. However, the code written to make course selections is based off this course local storage variable. We should think about consolidating and moving to just one local storage variable. Either by using one "courses" and one "catalog_year" local storage variable or we continue with just using the application local storage variable. Either way we would have to do a refactor to support whichever choice we make. 