### PR TITLE
Make API Return Data Across Multiple Years

### DIFF
--- a/app/api/course/[courseCode]/route.ts
+++ b/app/api/course/[courseCode]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
-import { ICourseDescriptionSchema, IPrereqSchema, IPropertiesSchema, IOfferedSchema } from "@/public/data/dataInterface";
+import { ICourseDescriptionSchema, IPrereqSchema, IPropertiesSchema, IOfferedSchema, ISingleYearOfferedSchema } from "@/public/data/dataInterface";
 import path from "path";
 import * as fs from "fs";
 
@@ -19,6 +19,7 @@ export async function GET(request: NextRequest) {
     attributes: undefined,
     term: undefined,
   };
+  let year = "2023-2024";
 
   for (let [k, v] of Object.entries(courseData)) {
     if (subjLooking === v.subj && idLooking === v.ID) {
@@ -37,12 +38,14 @@ export async function GET(request: NextRequest) {
         CI: v.properties.CI,
         major_restricted: v.properties.major_restricted,
       };
-      let courseSemester: IOfferedSchema = {
-        even: whenOffered.even,
-        odd: whenOffered.odd,
+      let offered_year: ISingleYearOfferedSchema = {
+        year: year,
         fall: whenOffered.fall,
         spring: whenOffered.spring,
         summer: whenOffered.summer,
+      };
+      let courseSemester: IOfferedSchema = {
+        years: [offered_year],
         uia: whenOffered.uia,
         text: whenOffered.text,
       };
@@ -56,7 +59,6 @@ export async function GET(request: NextRequest) {
       break;
     }
   }
-
   // Construct the combined course data
   // Return the response
   return NextResponse.json(response);

--- a/app/api/course/[courseCode]/route.ts
+++ b/app/api/course/[courseCode]/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse, NextRequest } from "next/server";
 import { ICourseDescriptionSchema, IPrereqSchema, IPropertiesSchema, IOfferedSchema, ISingleYearOfferedSchema } from "@/public/data/dataInterface";
+import { catalogList } from "@/public/data/staticData";
 import path from "path";
 import * as fs from "fs";
+import { template } from "lodash";
 
 // Main GET function
 export async function GET(request: NextRequest) {
@@ -9,9 +11,13 @@ export async function GET(request: NextRequest) {
   const selectedCourseCode = pathParts[pathParts.length - 1].toUpperCase();
   let subjLooking = selectedCourseCode.split("-")[0];
   let idLooking = selectedCourseCode.split("-")[1];
-  const jsonCourse = path.join(process.cwd(), "json") + `/2023-2024` + "/courses.json"
-  const courseData: Object = JSON.parse(fs.readFileSync(jsonCourse, "utf8"));
-  // Fetch data from external sources
+  const allData: Object[] = [];
+  for (let year of catalogList) {
+    const jsonYear = path.join(process.cwd(), "json") + `/${year.text}` + "/courses.json";
+    let yearData = JSON.parse(fs.readFileSync(jsonYear, "utf8"));
+    yearData.year = year.text;
+    allData.push(yearData);
+  }
   let response: ICourseDescriptionSchema = {
     title : "Course not found",
     description: "des not found",
@@ -19,7 +25,7 @@ export async function GET(request: NextRequest) {
     attributes: undefined,
     term: undefined,
   };
-  let year = "2023-2024";
+  let courseData = allData[allData.length - 1];
 
   for (let [k, v] of Object.entries(courseData)) {
     if (subjLooking === v.subj && idLooking === v.ID) {
@@ -38,14 +44,21 @@ export async function GET(request: NextRequest) {
         CI: v.properties.CI,
         major_restricted: v.properties.major_restricted,
       };
-      let offered_year: ISingleYearOfferedSchema = {
-        year: year,
-        fall: whenOffered.fall,
-        spring: whenOffered.spring,
-        summer: whenOffered.summer,
-      };
+      let offered_years: ISingleYearOfferedSchema[] = [];
+      for (let yearData of allData) {
+        for (let [i, j] of Object.entries(yearData)) {
+          if (j.subj === v.subj && j.ID === v.ID) {
+            offered_years.push({
+              year: yearData.year,
+              fall: j.offered.fall,
+              spring: j.offered.spring,
+              summer: j.offered.summer,
+            });
+          }
+        }
+      }
       let courseSemester: IOfferedSchema = {
-        years: [offered_year],
+        years: offered_years,
         uia: whenOffered.uia,
         text: whenOffered.text,
       };
@@ -59,7 +72,6 @@ export async function GET(request: NextRequest) {
       break;
     }
   }
-  // Construct the combined course data
   // Return the response
   return NextResponse.json(response);
 }

--- a/public/data/dataInterface.ts
+++ b/public/data/dataInterface.ts
@@ -36,12 +36,15 @@ export interface IPropertiesSchema {
   major_restricted: boolean;
 }
 
-export interface IOfferedSchema {
-  even: boolean;
-  odd: boolean;
+export interface ISingleYearOfferedSchema {
+  year: string;
   fall: boolean;
   spring: boolean;
   summer: boolean;
+}
+
+export interface IOfferedSchema {
+  years: Array<ISingleYearOfferedSchema>;
   uia: boolean;
   text: string;
 }


### PR DESCRIPTION
This mostly just is for the semester offered table, as the desired functionality of the individual course page and course search page isn't set in stone yet, so it's unclear if I need to check older jsons for course existence yet. So as of now, it simply iterates over the old jsons to check for semester offerings.