### PR TITLE
Make Names Consistent

### DIFF
--- a/app/components/navigation/Footer.tsx
+++ b/app/components/navigation/Footer.tsx
@@ -19,7 +19,7 @@ const Footer = () => {
                 <Link href="/courses">My Courses</Link>
                 <Link href="/courses/search">Search Courses</Link>
                 <Link href="/pathways">My Pathways</Link>
-                <Link href="/pathways/search">Search Pathways</Link>
+                <Link href="/pathways/search">Explore Pathways</Link>
             </div>
         </footer>
     );

--- a/app/contexts/appContext/AppProvider.tsx
+++ b/app/contexts/appContext/AppProvider.tsx
@@ -2,7 +2,7 @@
 
 import {createContext, ReactNode, useContext, useEffect, useReducer,} from "react";
 import {appReducer} from "./AppReducer";
-import {INITIAL_LOAD_DATA, SET_CATALOG, SET_COURSES} from "../actions";
+import {INITIAL_LOAD_DATA, SET_CATALOG, SET_COURSES, SET_PATHWAYS} from "../actions";
 import {APPLICATION_STATE_KEY, courseState, pathwaysCategories,} from "@/public/data/staticData";
 import {ApplicationContext} from "@/app/model/AppContextInterface";
 import {ICourseSchema} from "@/app/model/CourseInterface";

--- a/app/courses/search/page.tsx
+++ b/app/courses/search/page.tsx
@@ -21,7 +21,7 @@ const SearchCourse = () => {
     <>
       <header>
         <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-8">
-          <h1 className="title mb-3">Find Courses</h1>
+          <h1 className="title mb-3">Search Courses</h1>
           <Link href={"/courses"}>
             <span className="flex text-primary-700 gap-2 text-sm font-semibold">
               My Courses <ChevronRight />

--- a/app/pathways/search/page.tsx
+++ b/app/pathways/search/page.tsx
@@ -105,7 +105,7 @@ const SearchCourse = () => {
     <>
       <header className="flex flex-col gap-5">
         <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-8">
-          <h1 className="title mb-3">Find Pathways</h1>
+          <h1 className="title mb-3">Explore Pathways</h1>
           <Link href={"/pathways"}>
             <span className="flex text-primary-700 gap-2 text-sm font-semibold">
               My Pathways <ChevronRight />


### PR DESCRIPTION
Closes #51 

Updates Explore pathways to be the name across the website. Same for Search Courses. Also was missing an import in the App Provider. Made a mistake when resolving a merge conflict in #44 and #61. 