### PR TITLE
Make pathway api fix course id formatting before outputting

### DIFF
--- a/app/api/pathway/search/route.ts
+++ b/app/api/pathway/search/route.ts
@@ -18,16 +18,17 @@ export async function GET(request: NextRequest) {
   );
 
   let blob = pathways;
-  console.log(blob.Economics);
   let flatten: any = {};
   for (var [name, v] of Object.entries(blob)) {
     let coursesIn = [];
     let department = "Depreciated";
     for (var [k, c] of Object.entries(v)) {
-      console.log(c);
       if (typeof c === "object" && k != "minor") {
         for (var [title, code] of Object.entries(c)) {
-          coursesIn.push(code);
+          if (code.length == 8){
+            code = [code.slice(0, 4), "-", code.slice(4)].join('');
+          }
+          coursesIn.push(code.replace(" ", "-"));
         }
       }
     }
@@ -51,7 +52,6 @@ export async function GET(request: NextRequest) {
       )
     );
   }
-  console.log(flatten);
 
   const departmentFilter = params.get("department");
   if (departmentFilter) {
@@ -72,8 +72,8 @@ export async function GET(request: NextRequest) {
       department: data.department,
     };
   });
-
- // console.log(output);
+  
+  //console.log(output);
   
   return NextResponse.json(output);
 }

--- a/json/2019-2020/pathways.json
+++ b/json/2019-2020/pathways.json
@@ -114,7 +114,7 @@
     "Remaining": {
       "Design and Innovation  Studio C": "STSS4610",
       "Design and Innovation Studio B": "STSH4610",
-      "Design and Innovation Studio C": null
+      "Design and Innovation Studio C": "ENGR 4610"
     },
     "Required": {
       "Design and Innovation Studio I": "IHSS1610",

--- a/json/2020-2021/pathways.json
+++ b/json/2020-2021/pathways.json
@@ -118,7 +118,7 @@
     "Remaining": {
       "Design and Innovation  Studio C": "STSS4610",
       "Design and Innovation Studio B": "STSH4610",
-      "Design and Innovation Studio C": null
+      "Design and Innovation Studio C": "ENGR 4610"
     },
     "Required": {
       "Design and Innovation Studio I": "IHSS1610",

--- a/json/2021-2022/pathways.json
+++ b/json/2021-2022/pathways.json
@@ -113,7 +113,7 @@
     "Remaining": {
       "Design and Innovation  Studio C": "STSO4610",
       "Design and Innovation Studio B": "STSO4605",
-      "Design and Innovation Studio C": null
+      "Design and Innovation Studio C": "ENGR 4610"
     },
     "Required": {
       "Design and Innovation Studio I": "IHSS1610",


### PR DESCRIPTION
I cannot believe they put "null" in this json file. I am astounded at the idea to have a different data type as the value in the key value pair, much less "null", the most annoying of all of the types it could be. You can also see 2 lines above that there is a key which is the exact same but with a space in it. The original designers of this format should have realized then that using course names as the key was a bad idea, but alas, I must fight on as HASSPathway's strongest soldier.