### PR TITLE
#140 Fix course filter grid

### DIFF
--- a/app/components/course/SearchComponent.tsx
+++ b/app/components/course/SearchComponent.tsx
@@ -203,7 +203,7 @@ const DesktopFilter = ({ filterState, filterDispatch }: FilterProps) => {
               const selected = filterState[section.apiName].includes(choice.value);
               const actionType = selected ? FilterAction.REM : FilterAction.ADD;
               return (
-                <div className="px-2 py-2 flex-grow basis-1/3" key={choice.value}>
+                <div className="px-2 py-2 flex-grow basis-0" key={choice.value}>
                   <div
                     className="cursor-pointer flex gap-2 items-start"
                     onClick={() => {

--- a/app/components/course/SearchComponent.tsx
+++ b/app/components/course/SearchComponent.tsx
@@ -203,9 +203,9 @@ const DesktopFilter = ({ filterState, filterDispatch }: FilterProps) => {
               const selected = filterState[section.apiName].includes(choice.value);
               const actionType = selected ? FilterAction.REM : FilterAction.ADD;
               return (
-                <div className="px-3 py-2 basis-auto shrink-0" key={choice.value}>
+                <div className="px-2 py-2 flex-grow basis-1/3" key={choice.value}>
                   <div
-                    className="cursor-pointer flex gap-2 items-center"
+                    className="cursor-pointer flex gap-2 items-start"
                     onClick={() => {
                       filterDispatch({
                         type: actionType,
@@ -216,8 +216,8 @@ const DesktopFilter = ({ filterState, filterDispatch }: FilterProps) => {
                       });
                     }}
                   >
-                    {selected ? <CheckBoxChecked /> : <CheckBoxUnChecked />}
-                    <label className={`text-sm shrink-0 cursor-pointer ${selected && "font-medium"}`}>
+                    <div className="shrink-0"> {selected ? <CheckBoxChecked /> : <CheckBoxUnChecked />} </div>
+                    <label className={`text-sm break-words cursor-pointer ${selected && "font-medium"}`}>
                       {choice.displayName}
                     </label>
                   </div>


### PR DESCRIPTION
Closes #140 

Two things that might be undesirable are that the top of the checkbox doesn't line up with the text, despite my use of items-start, and I use break-words to allow long filter titles like communication intensive to not overflow.